### PR TITLE
Ka VS Code kah claude  ê設定

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "name": "Claude Code Sandbox",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {}
+    },
+    // 【關鍵：掛載Linux主機ê .claude 登入資訊到容器內】
+    "mounts": [
+        "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+        "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached"
+
+    ],
+    // 【關鍵新增：Kā Claude Code 講，設定檔tī tsia】
+    "remoteEnv": {
+        "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "anthropic.claude-dev"
+            ]
+        }
+    },
+    "postCreateCommand": "npm install -g @anthropic-ai/claude-code @fission-ai/openspec@latest",
+    "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,6 @@
             ]
         }
     },
-    "postCreateCommand": "npm install -g @anthropic-ai/claude-code @fission-ai/openspec@latest",
+    "postCreateCommand": "npm install -g @fission-ai/openspec@latest",
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "anthropic.claude-dev"
+                "anthropic.claude-code"
             ]
         }
     },


### PR DESCRIPTION

## PR描述

- PR類型：新功能
- Issue連結：無
- 為什麼要有這支PR：用Claude開發ê安全設定

## 變更影響

- 系統新版調整為：無
- 組態調整為：無
- 工作流程調整為：ē-tàng用VS Code + Claude Code開發

## 備註
SOP記tī [VS Code 開發環境隔離建置作業說明書](https://docs.google.com/document/d/17Wx5peEzWe3x2LZFJug4VIJp5cpVFG4lGzCP--DGaok/edit?usp=sharing)

## Demo畫面
<img width="1920" height="1080" alt="圖片" src="https://github.com/user-attachments/assets/368d0ac0-a828-436a-a9a1-49b4833276e8" />
